### PR TITLE
Fix old documentation

### DIFF
--- a/reactors-core/src/main/scala/io/reactors/Channel.scala
+++ b/reactors-core/src/main/scala/io/reactors/Channel.scala
@@ -7,11 +7,11 @@ import io.reactors.concurrent.Frame
 
 
 
-/** `Channel` is a shareable reference to a writing endpoint of an isolate.
+/** `Channel` is a shareable reference to a writing endpoint of a reactor.
  *
  *  By calling the channel's `!` method, an event is sent to the channel. The event is
  *  eventually emitted on the channel's corresponding event stream, which is readable
- *  only by the isolate that owns that channel.
+ *  only by the reactor that owns that channel.
  *
  *  @tparam T       type of the events propagated by this channel
  */


### PR DESCRIPTION
This was probably left over after the refactoring from somewhere around here:

https://github.com/reactors-io/reactors/commit/04854812ad5844ec9f969aa72325a376a179c27e