### PR TITLE
Output reactor uid in addition to its name.

### DIFF
--- a/reactors-core/src/main/scala/io/reactors/concurrent/Services.scala
+++ b/reactors-core/src/main/scala/io/reactors/concurrent/Services.scala
@@ -93,7 +93,8 @@ object Services {
   private def loggingTag(): String = {
     val time = System.currentTimeMillis()
     val formattedTime = timestampFormat.format(new Date(time))
-    s"[$formattedTime ${Reactor.self[Nothing].frame.name}] "
+    val frame = Reactor.self[Nothing].frame
+    s"[$formattedTime | ${frame.name} (${frame.uid})] "
   }
 
   /** Contains services needed to communicate with the debugger.


### PR DESCRIPTION
This is useful info when multiple reactors reuse the same frame name at different times.