### PR TITLE
working on updating to scala 2.12 and updating associated dependencies

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,3 @@
+rewrites = ["https://gist.githubusercontent.com/sjrd/ef8bb7c52be1451b3a3b9bab6a187549/raw/0b1d451d266bce20921bbff3a74722610d604509/ScalaJSRewrites.scala"]
+imports.organize = false
+imports.removeUnused = false

--- a/dependencies.conf
+++ b/dependencies.conf
@@ -7,7 +7,7 @@ reactors-common-jvm = [
     repo = "scalameter"
     project = "scalameter"
     configuration = "test->test"
-    artifact = ["com.storm-enroute", "scalameter", "0.9-SNAPSHOT", "test;bench"]
+    artifact = ["com.storm-enroute", "scalameter", "0.8.2", "test;bench"]
   }
 ]
 
@@ -22,7 +22,7 @@ reactors-core-jvm = [
     repo = "scalameter"
     project = "scalameter"
     configuration = "test->test"
-    artifact = ["com.storm-enroute", "scalameter", "0.9-SNAPSHOT", "test;bench"]
+    artifact = ["com.storm-enroute", "scalameter", "0.8.2", "test;bench"]
   }
 ]
 
@@ -37,7 +37,7 @@ reactors-container-jvm = [
     repo = "scalameter"
     project = "scalameter"
     configuration = "test->test"
-    artifact = ["com.storm-enroute", "scalameter", "0.9-SNAPSHOT", "test;bench"]
+    artifact = ["com.storm-enroute", "scalameter", "0.8.2", "test;bench"]
   }
 ]
 
@@ -67,7 +67,7 @@ reactors-extra = [
     repo = "scalameter"
     project = "scalameter"
     configuration = "test->test"
-    artifact = ["com.storm-enroute", "scalameter", "0.9-SNAPSHOT", "test;bench"]
+    artifact = ["com.storm-enroute", "scalameter", "0.8.2", "test;bench"]
   }
 ]
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -15,7 +15,8 @@ import org.scalajs.sbtplugin.cross.CrossProject
 object ReactorsBuild extends MechaRepoBuild {
   def repoName = "reactors"
 
-  val reactorsScalaVersion = "2.11.8"
+  val reactorsScalaVersion = "2.12.2"
+  val scalaCheckVersion = "1.13.5"
 
   def projectSettings(suffix: String) = {
     Seq(
@@ -123,7 +124,7 @@ object ReactorsBuild extends MechaRepoBuild {
       projectSettings("-common") ++ Seq(
         libraryDependencies ++= Seq(
           "org.scalatest" %%% "scalatest" % "3.0.0" % "test",
-          "org.scalacheck" %%% "scalacheck" % "1.13.2" % "test"
+          "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % "test"
         ),
         unmanagedSourceDirectories in Compile +=
           baseDirectory.value.getParentFile / "shared" / "src" / "main" / "scala",
@@ -136,7 +137,7 @@ object ReactorsBuild extends MechaRepoBuild {
     .jvmSettings(
       jvmProjectSettings("-common") ++ Seq(
         libraryDependencies ++= Seq(
-          "com.typesafe.akka" %% "akka-actor" % "2.3.15" % "test;bench"
+          "com.typesafe.akka" %% "akka-actor" % "2.5.0" % "test;bench"
         ),
         libraryDependencies ++= superRepoDependencies(s"reactors-common-jvm")
       ): _*
@@ -163,7 +164,7 @@ object ReactorsBuild extends MechaRepoBuild {
           },
         libraryDependencies ++= Seq(
           "org.scalatest" %%% "scalatest" % "3.0.0" % "test",
-          "org.scalacheck" %%% "scalacheck" % "1.13.2" % "test"
+          "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % "test"
         ),
         unmanagedSourceDirectories in Compile +=
           baseDirectory.value.getParentFile / "shared" / "src" / "main" / "scala",
@@ -191,7 +192,7 @@ object ReactorsBuild extends MechaRepoBuild {
       fork in run := false,
       scalaJSUseRhino in Global := false,
       libraryDependencies ++= Seq(
-        "org.scala-js" %%% "scala-parser-combinators" % "1.0.2"
+        "org.scala-lang.modules" %%% "scala-parser-combinators" % "1.0.5"
       )
     )
     .jsConfigure(_.copy(id = "reactors-core-js").dependsOnSuperRepo)
@@ -209,7 +210,7 @@ object ReactorsBuild extends MechaRepoBuild {
       projectSettings("-container") ++ Seq(
         libraryDependencies ++= Seq(
           "org.scalatest" %%% "scalatest" % "3.0.0" % "test",
-          "org.scalacheck" %%% "scalacheck" % "1.13.2" % "test"
+          "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % "test"
         ),
         unmanagedSourceDirectories in Compile +=
           baseDirectory.value.getParentFile / "shared" / "src" / "main" / "scala",
@@ -248,7 +249,7 @@ object ReactorsBuild extends MechaRepoBuild {
       projectSettings("-protocol") ++ Seq(
         libraryDependencies ++= Seq(
           "org.scalatest" %%% "scalatest" % "3.0.0" % "test",
-          "org.scalacheck" %%% "scalacheck" % "1.13.2" % "test"
+          "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % "test"
         ),
         unmanagedSourceDirectories in Compile +=
           baseDirectory.value.getParentFile / "shared" / "src" / "main" / "scala",
@@ -289,8 +290,8 @@ object ReactorsBuild extends MechaRepoBuild {
       projectSettings("-remote") ++ Seq(
         libraryDependencies ++= Seq(
           "org.scalatest" %%% "scalatest" % "3.0.0" % "test",
-          "org.scalacheck" %%% "scalacheck" % "1.13.2" % "test",
-          "org.scala-lang" % "scala-reflect" % "2.11.8"
+          "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % "test",
+          "org.scala-lang" % "scala-reflect" % reactorsScalaVersion
         ),
         unmanagedSourceDirectories in Compile +=
           baseDirectory.value.getParentFile / "shared" / "src" / "main" / "scala",
@@ -329,9 +330,9 @@ object ReactorsBuild extends MechaRepoBuild {
     .settings(
       jvmProjectSettings("-extra") ++ projectSettings("-extra") ++ Seq(
         libraryDependencies ++= Seq(
-          "org.scala-lang" % "scala-reflect" % "2.11.4",
+          "org.scala-lang" % "scala-reflect" % reactorsScalaVersion,
           "org.scalatest" %%% "scalatest" % "3.0.0" % "test",
-          "org.scalacheck" %%% "scalacheck" % "1.13.2" % "test",
+          "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % "test",
           "com.typesafe.akka" %% "akka-actor" % "2.3.15" % "test;bench"
         )
       ): _*
@@ -354,10 +355,10 @@ object ReactorsBuild extends MechaRepoBuild {
     .settings(
       jvmProjectSettings("-http") ++ projectSettings("-http") ++ Seq(
         libraryDependencies ++= Seq(
-          "org.scala-lang" % "scala-compiler" % "2.11.8",
+          "org.scala-lang" % "scala-compiler" % "2.12.1", //FIXME: reactorsScalaVersion,
           "org.nanohttpd" % "nanohttpd" % "2.3.1",
           "org.scalatest" %%% "scalatest" % "3.0.0" % "test",
-          "org.scalacheck" %%% "scalacheck" % "1.13.2" % "test",
+          "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % "test",
           "org.seleniumhq.selenium" % "selenium-java" % "2.53.1" % "test",
           "org.seleniumhq.selenium" % "selenium-chrome-driver" % "2.53.1" % "test"
         )
@@ -381,14 +382,14 @@ object ReactorsBuild extends MechaRepoBuild {
     .settings(
       jvmProjectSettings("-debugger") ++ projectSettings("-debugger") ++ Seq(
         libraryDependencies ++= Seq(
-          "org.scala-lang" % "scala-compiler" % "2.11.8",
+          "org.scala-lang" % "scala-compiler" % reactorsScalaVersion,
           "org.rapidoid" % "rapidoid-http-server" % "5.1.9",
           "org.rapidoid" % "rapidoid-gui" % "5.1.9",
           "com.github.spullara.mustache.java" % "compiler" % "0.9.2",
           "commons-io" % "commons-io" % "2.4",
-          "org.json4s" %% "json4s-jackson" % "3.4.0",
+          "org.json4s" %% "json4s-jackson" % "3.5.1",
           "org.scalatest" %%% "scalatest" % "3.0.0" % "test",
-          "org.scalacheck" %%% "scalacheck" % "1.13.2" % "test",
+          "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % "test",
           "org.seleniumhq.selenium" % "selenium-java" % "2.53.1" % "test",
           "org.seleniumhq.selenium" % "selenium-chrome-driver" % "2.53.1" % "test"
         )
@@ -412,7 +413,7 @@ object ReactorsBuild extends MechaRepoBuild {
       projectSettings("") ++ Seq(
         libraryDependencies ++= Seq(
           "org.scalatest" %%% "scalatest" % "3.0.0" % "test",
-          "org.scalacheck" %%% "scalacheck" % "1.13.2" % "test"
+          "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % "test"
         ),
         unmanagedSourceDirectories in Compile +=
           baseDirectory.value.getParentFile / "shared" / "src" / "main" / "scala",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.15

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,10 +8,14 @@ resolvers ++= Seq(
   "Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases"
 )
 
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC1")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.3.2")
+
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.1")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
+//addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.12")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.15")
 
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")


### PR DESCRIPTION
A few known issues with this PR that I haven't yet been able to fix:

1. In `io/reactors/JvmScheduler.scala`, I get: `[error]  found   : scala.concurrent.ExecutionContext
[error]  required: java.util.concurrent.Executor` . A quick search turns up https://github.com/scala/community-builds/issues/272 ; I  think I'm slightly out of my depth here on how to best proceed, so I haven't tried fixing this yet.
2. IntelliJ (at least) can't seem to find `Platform` in `io/reactors/concurrent/Services.scala` - what is it or where is it coming from?
3. `sbt scalafix fails` also, haven't looked into why ([see here](https://www.scala-js.org/news/2017/03/21/announcing-scalajs-0.6.15/)). The associated plugin and .scalafix.conf should be removed once working; and if it doesn't help, the fixes can probably be done manually.
4. One dependency (scala-compiler) should be updated to match other scala versions (2.12.2) once available on maven central -- see `FIXME` comment.